### PR TITLE
Fix Swagger UI doc paths on production (non-localhost) url's

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ To deploy a new version to kylix-demo-prod from the root of the application:
 3) Bump the semantic version using npm version command. Examples:
   * `npm version major --force`
   * `npm version minor --force`
-  * `npm version minor --force`
+  * `npm version patch --force`
   * `npm version [v0.0.0] --force`
+  * `npm version prepatch --force` (example of a non-semver version if you are testing deploy on a branch)
   More options here: https://docs.npmjs.com/cli/v7/commands/npm-version
 4) Run `eb deploy kylix-env -l $(npm view kylix version)`
 This labels the elastic beanstalk version with the npm version created in the last step, to connect them together. Then it sends code up to S3 & deploys application

--- a/src/api/mock-server/api-server.js
+++ b/src/api/mock-server/api-server.js
@@ -4,13 +4,11 @@ const bodyParser = require('body-parser');
 const useRoutes = require('./useRoutes');
 const useApiDocs = require('./useApiDocs');
 
-const apiServer = async (_app, _port) => {
+const apiServer = async (_app) => {
   const app = _app || express();
-  const port = _port || process.env.PORT || 5000;
-
   app.use(bodyParser.json());
   useRoutes(app);
-  await useApiDocs(app, port);
+  await useApiDocs(app);
 };
 
 module.exports = apiServer;

--- a/src/api/mock-server/useApiDocs.js
+++ b/src/api/mock-server/useApiDocs.js
@@ -6,15 +6,15 @@ const SwaggerParser = require('@apidevtools/swagger-parser');
 
 const specPath = path.join(__dirname, '../api-docs/api-doc.yaml');
 
-module.exports = async function useApiDocs(app, port) {
+module.exports = async function useApiDocs(app) {
   const specObj = await SwaggerParser.bundle(specPath);
   const options = {
     swaggerDefinition: {
       ...specObj,
       servers: [
         {
-          url: `http://localhost:${port}/api`,
-          description: 'Local mock server instance',
+          url: '/api',
+          description: 'Mock server instance',
         },
       ],
     },

--- a/src/scripts/server.js
+++ b/src/scripts/server.js
@@ -3,6 +3,7 @@ const path = require('path');
 const apiServer = require('../api/mock-server/api-server');
 
 const port = process.env.PORT || 5000; // this is the serverPort in dev as well
+const webPort = process.env.WEB_PORT || 9000;
 
 // elastic beanstalk invokes all processes with NODE_ENV='production'
 const env = process.env.NODE_ENV || 'development';
@@ -10,7 +11,7 @@ const env = process.env.NODE_ENV || 'development';
 const app = express();
 
 const startServer = async () => {
-  await apiServer(app, port);
+  await apiServer(app);
 
   // only serve static files in prod
   // as we use webpack dev server for development
@@ -28,12 +29,19 @@ const startServer = async () => {
     if (err) {
       console.log(err);
     } else {
-      if (env !== 'dev') {
+      const isProd = env === 'production';
+      if (isProd) {
         console.log(`\nKylix running at http://localhost:${port}`);
       }
-      console.log(`\nKylix api running at http://localhost:${port}/api`);
-      console.log(`\nDocs at http://localhost:${port}/api-docs`);
-      console.log(`\nVerify at http://localhost:${port}/api/ping`);
+      const serverUrl = `http://localhost:${port}`;
+      const webUrl = isProd ? serverUrl: `http://localhost:${webPort}`;
+      console.log(`\nKylix api running at ${webUrl}/api`);
+      console.log(`\nDocs at ${webUrl}/api-docs`);
+      console.log(`\nVerify at ${webUrl}/api/ping`);
+      if (env === 'development') {
+        console.log('Make sure you are running webpack');
+        console.log(`Webpack proxies server requests from ${webUrl} to ${serverUrl}`);
+      }
     }
   });
 };

--- a/src/scripts/server.js
+++ b/src/scripts/server.js
@@ -14,7 +14,7 @@ const startServer = async () => {
 
   // only serve static files in prod
   // as we use webpack dev server for development
-  if (env !== 'dev') {
+  if (env === 'production') {
   // Serve the static files from the React app
     app.use('/', express.static(path.join(__dirname, '../../dist')));
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const path = require('path');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
-const clientPort = process.env.WEB_PORT || 9000;
+const webPort = process.env.WEB_PORT || 9000;
 const serverPort = process.env.PORT || 5000;
 
 const config = {
@@ -18,7 +18,7 @@ const config = {
   devServer: {
     contentBase: path.join(__dirname, 'dist'),
     compress: true,
-    port: clientPort,
+    port: webPort,
     historyApiFallback: true,
     proxy: {
       '/api/**': { target: `http://localhost:${serverPort}`, changeOrigin: true },


### PR DESCRIPTION
See http://kylix-env.eba-4iemcn7i.us-east-1.elasticbeanstalk.com/api-docs 
